### PR TITLE
Check queue is not empty when deciding

### DIFF
--- a/src/components/vue-tinder/open-methods.js
+++ b/src/components/vue-tinder/open-methods.js
@@ -10,7 +10,7 @@ export default {
      * @param {String} type like：喜欢，nope：不喜欢，super：超喜欢，down：向下
      */
     decide(type) {
-      if (this.state.touchId || this.status !== STATUS.NORMAL) {
+      if (this.state.touchId || this.status !== STATUS.NORMAL || !this.queue.length) {
         return
       }
       this.state.start = { x: 0, y: 0 }


### PR DESCRIPTION
Correct a bug when you try to "decide" and the queue is empty which triggers a fatal error